### PR TITLE
Migration & Mapping Console commands

### DIFF
--- a/config/doctrine.php
+++ b/config/doctrine.php
@@ -1,10 +1,9 @@
 <?php
 
 return [
-    'simple_annotations' => false,
-
     'metadata' => [
-        // Paths to entities here...
+        'driver' => 'annotation',
+        'simple' => false
     ],
 
     'proxy' => [
@@ -32,5 +31,10 @@ return [
 
     'repositoryFactory' => null,
 
-    'logger' => null
+    'logger' => null,
+
+    'migrations' => [
+        'directory' => base_path('database/doctrine/migrations'),
+        'namespace' => 'App\Migrations'
+    ]
 ];

--- a/src/Console/ConvertMapping.php
+++ b/src/Console/ConvertMapping.php
@@ -1,0 +1,173 @@
+<?php namespace Mitch\LaravelDoctrine\Console;
+
+use Illuminate\Console\Command;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Input\InputArgument;
+use Doctrine\ORM\Mapping\Driver\DatabaseDriver;
+use Doctrine\ORM\Tools\DisconnectedClassMetadataFactory;
+use Doctrine\ORM\Tools\Console\MetadataFilter;
+use Doctrine\ORM\Tools\Export\ClassMetadataExporter;
+use Doctrine\ORM\Tools\EntityGenerator;
+
+class ConvertMapping extends Command {
+
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $name = 'doctrine:mapping:convert';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Convert mapping information between supported formats.';
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function fire()
+    {
+        $entityManager = $this->laravel->make('Doctrine\ORM\EntityManagerInterface');
+        if ($this->option('from-database') === true) {
+            $databaseDriver = new DatabaseDriver(
+                $entityManager->getConnection()->getSchemaManager()
+            );
+            $entityManager->getConfiguration()->setMetadataDriverImpl(
+                $databaseDriver
+            );
+            if (($namespace = $this->option('namespace')) !== null) {
+                $databaseDriver->setNamespace($namespace);
+            }
+        }
+
+        $cmf = new DisconnectedClassMetadataFactory();
+        $cmf->setEntityManager($entityManager);
+        $metadata = $cmf->getAllMetadata();
+        $metadata = MetadataFilter::filter($metadata, $this->option('filter'));
+
+        // Process destination directory
+        if ( ! is_dir($destPath = $this->argument('dest-path'))) {
+            mkdir($destPath, 0777, true);
+        }
+
+        $destPath = realpath($destPath);
+        if ( ! file_exists($destPath)) {
+            throw new \InvalidArgumentException(
+                sprintf("Mapping destination directory '<info>%s</info>' does not exist.",
+                    $this->argument('dest-path'))
+            );
+        }
+
+        if ( ! is_writable($destPath)) {
+            throw new \InvalidArgumentException(
+                sprintf("Mapping destination directory '<info>%s</info>' does not have write permissions.", $destPath)
+            );
+        }
+
+        $toType = strtolower($this->argument('to-type'));
+        $exporter = $this->getExporter($toType, $destPath);
+        $exporter->setOverwriteExistingFiles($this->option('force'));
+
+        if ($toType == 'annotation') {
+            $entityGenerator = new EntityGenerator();
+            $exporter->setEntityGenerator($entityGenerator);
+            $entityGenerator->setNumSpaces($this->option('num-spaces'));
+            if (($extend = $this->option('extend')) !== null) {
+                $entityGenerator->setClassToExtend($extend);
+            }
+        }
+
+        if (count($metadata)) {
+            foreach ($metadata as $class) {
+                $this->info(sprintf('Processing entity "<info>%s</info>"', $class->name));
+            }
+            $exporter->setMetadata($metadata);
+            $exporter->export();
+            $this->info(PHP_EOL . sprintf(
+                    'Exporting "<info>%s</info>" mapping information to "<info>%s</info>"', $toType, $destPath
+                ));
+        } else {
+            $this->info('No Metadata Classes to process.');
+        }
+    }
+
+    /**
+     * Get the console command arguments.
+     *
+     * @return array
+     */
+    protected function getArguments()
+    {
+        return [
+            ['to-type', InputArgument::REQUIRED, 'The mapping type to be converted.'],
+            ['dest-path', InputArgument::REQUIRED, 'The path to generate your entities classes.'],
+        ];
+    }
+
+    /**
+     * Get the console command options.
+     *
+     * @return array
+     */
+    protected function getOptions()
+    {
+        return [
+            [
+                'filter',
+                null,
+                InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY,
+                'A string pattern used to match entities that should be processed.'
+            ],
+            [
+                'force',
+                'f',
+                InputOption::VALUE_NONE,
+                'Force to overwrite existing mapping files.'
+            ],
+            [
+                'from-database',
+                null,
+                null,
+                'Whether or not to convert mapping information from existing database.'
+            ],
+            [
+                'extend',
+                null,
+                InputOption::VALUE_OPTIONAL,
+                'Defines a base class to be extended by generated entity classes.'
+            ],
+            [
+                'num-spaces',
+                null,
+                InputOption::VALUE_OPTIONAL,
+                'Defines the number of indentation spaces.',
+                4
+            ],
+            [
+                'namespace',
+                null,
+                InputOption::VALUE_OPTIONAL,
+                'Defines a namespace for the generated entity classes, if converted from database.'
+            ],
+        ];
+    }
+
+    /**
+     * @param string $toType
+     * @param string $destPath
+     *
+     * @return \Doctrine\ORM\Tools\Export\Driver\AbstractExporter
+     */
+    protected function getExporter($toType, $destPath)
+    {
+        $cme = new ClassMetadataExporter();
+
+        return $cme->getExporter($toType, $destPath);
+    }
+
+}

--- a/src/Console/Migrations/AbstractCommand.php
+++ b/src/Console/Migrations/AbstractCommand.php
@@ -1,0 +1,114 @@
+<?php namespace Mitch\LaravelDoctrine\Console\Migrations;
+
+use Illuminate\Console\Command;
+use Doctrine\DBAL\Migrations\Configuration\Configuration;
+use Doctrine\DBAL\Migrations\Configuration\YamlConfiguration;
+use Doctrine\DBAL\Migrations\Configuration\XmlConfiguration;
+use Doctrine\DBAL\Migrations\OutputWriter;
+use Symfony\Component\Console\Input\InputOption;
+
+abstract class AbstractCommand extends Command
+{
+    /**
+     * The configuration property only contains the configuration injected by the setter.
+     *
+     * @var Configuration
+     */
+    private $configuration;
+
+    /**
+     * The migrationConfiguration property contains the configuration
+     * created taking into account the command line options.
+     *
+     * @var Configuration
+     */
+    private $migrationConfiguration;
+
+    /**
+     * @var OutputWriter
+     */
+    private $outputWriter;
+
+    /**
+     * @var \Doctrine\DBAL\Connection
+     */
+    private $connection;
+
+    public function __construct()
+    {
+        parent::__construct($this->name);
+    }
+
+    protected function outputHeader(Configuration $configuration)
+    {
+        $name = $configuration->getName();
+        $name = $name ? $name : 'Doctrine Database Migrations';
+        $name = str_repeat(' ', 20) . $name . str_repeat(' ', 20);
+        $this->question(str_repeat(' ', strlen($name)));
+        $this->question($name);
+        $this->question(str_repeat(' ', strlen($name)));
+        $this->line('');
+    }
+
+    public function setMigrationConfiguration(Configuration $config)
+    {
+        $this->configuration = $config;
+    }
+
+    /**
+     * When any (config) command line option is passed to the migration the migrationConfiguration
+     * property is set with the new generated configuration.
+     * If no (config) option is passed the migrationConfiguration property is set to the value
+     * of the configuration one (if any).
+     * Else a new configuration is created and assigned to the migrationConfiguration property.
+     *
+     * @return Configuration
+     */
+    protected function getMigrationConfiguration()
+    {
+        if ( ! $this->migrationConfiguration) {
+            $config = config('doctrine.migrations');
+            $directory = array_get($config, 'directory');
+            if ( ! is_dir($directory)) {
+                mkdir($directory, 0777, true);
+            }
+
+            $configuration = new Configuration($this->getConnection(), $this->getOutputWriter());
+            $configuration->setMigrationsDirectory(array_get($config, 'directory'));
+            $configuration->setMigrationsNamespace(array_get($config, 'namespace'));
+            $configuration->setMigrationsTableName(array_get($config, 'table', 'doctrine_migration_versions'));
+            $configuration->registerMigrationsFromDirectory(array_get($config, 'directory'));
+            $this->migrationConfiguration = $configuration;
+        }
+
+        return $this->migrationConfiguration;
+    }
+
+    /**
+     * @return \Doctrine\DBAL\Migrations\OutputWriter
+     */
+    private function getOutputWriter()
+    {
+        if ( ! $this->outputWriter) {
+            $this->outputWriter = new OutputWriter(function ($message) {
+                return $this->output->writeln($message);
+            });
+        }
+
+        return $this->outputWriter;
+    }
+
+    /**
+     * @return \Doctrine\DBAL\Connection
+     * @throws \Doctrine\DBAL\DBALException
+     */
+    private function getConnection()
+    {
+        if ( ! $this->connection) {
+            $entityManager = $this->laravel->make('Doctrine\ORM\EntityManagerInterface');
+            $this->connection = $entityManager->getConnection();
+        }
+
+        return $this->connection;
+    }
+}

--- a/src/Console/Migrations/DiffCommand.php
+++ b/src/Console/Migrations/DiffCommand.php
@@ -1,0 +1,123 @@
+<?php namespace Mitch\LaravelDoctrine\Console\Migrations;
+
+use Symfony\Component\Console\Input\InputOption;
+use Doctrine\DBAL\Migrations\Configuration\Configuration;
+use Doctrine\ORM\Tools\SchemaTool;
+
+class DiffCommand extends GenerateCommand {
+
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $name = 'doctrine:migrations:diff';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Generate a migration by comparing your current database to your mapping information.';
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function fire()
+    {
+        $configuration = $this->getMigrationConfiguration();
+
+        $entityManager = $this->laravel->make('Doctrine\ORM\EntityManagerInterface');
+        $conn = $entityManager->getConnection();
+        $platform = $conn->getDatabasePlatform();
+        $metadata = $entityManager->getMetadataFactory()->getAllMetadata();
+
+        if (empty($metadata)) {
+            $this->info('No mapping information to process.', 'ERROR');
+
+            return;
+        }
+
+        if ($filterExpr = $this->option('filter-expression')) {
+            $conn->getConfiguration()
+                ->setFilterSchemaAssetsExpression($filterExpr);
+        }
+
+        $tool = new SchemaTool($entityManager);
+
+        $fromSchema = $conn->getSchemaManager()->createSchema();
+        $toSchema = $tool->getSchemaFromMetadata($metadata);
+
+        //Not using value from options, because filters can be set from config.yml
+        if ($filterExpr = $conn->getConfiguration()->getFilterSchemaAssetsExpression()) {
+            $tableNames = $toSchema->getTableNames();
+            foreach ($tableNames as $tableName) {
+                $tableName = substr($tableName, strpos($tableName, '.') + 1);
+                if ( ! preg_match($filterExpr, $tableName)) {
+                    $toSchema->dropTable($tableName);
+                }
+            }
+        }
+
+        $up = $this->buildCodeFromSql($configuration, $fromSchema->getMigrateToSql($toSchema, $platform));
+        $down = $this->buildCodeFromSql($configuration, $fromSchema->getMigrateFromSql($toSchema, $platform));
+
+        if ( ! $up && ! $down) {
+            $this->info('No changes detected in your mapping information.', 'ERROR');
+
+            return;
+        }
+
+        $version = date('YmdHis');
+        $path = $this->generateMigration($configuration, $version, $up, $down);
+
+        $this->info(sprintf('Generated new migration class to "<info>%s</info>" from schema differences.', $path));
+    }
+
+    /**
+     * Get the console command options.
+     *
+     * @return array
+     */
+    protected function getOptions()
+    {
+        $options = [
+            [
+                'filter-expression',
+                null,
+                InputOption::VALUE_OPTIONAL,
+                'Tables which are filtered by Regular Expression.'
+            ]
+        ];
+        return array_merge(parent::getOptions(), $options);
+    }
+
+    private function buildCodeFromSql(Configuration $configuration, array $sql)
+    {
+        $currentPlatform = $configuration->getConnection()->getDatabasePlatform()->getName();
+        $code = array();
+        foreach ($sql as $query) {
+            if (stripos($query, $configuration->getMigrationsTableName()) !== false) {
+                continue;
+            }
+            $code[] = sprintf("\$this->addSql(%s);", var_export($query, true));
+        }
+
+        if ($code) {
+            array_unshift(
+                $code,
+                sprintf(
+                    "\$this->abortIf(\$this->connection->getDatabasePlatform()->getName() != %s, %s);",
+                    var_export($currentPlatform, true),
+                    var_export(sprintf("Migration can only be executed safely on '%s'.", $currentPlatform), true)
+                ),
+                ""
+            );
+        }
+
+        return implode("\n", $code);
+    }
+
+}

--- a/src/Console/Migrations/ExecuteCommand.php
+++ b/src/Console/Migrations/ExecuteCommand.php
@@ -1,0 +1,91 @@
+<?php namespace Mitch\LaravelDoctrine\Console\Migrations;
+
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Input\InputArgument;
+
+class ExecuteCommand extends AbstractCommand {
+
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $name = 'doctrine:migrations:execute';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Execute a single migration version up or down manually.';
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function fire()
+    {
+        $version = $this->argument('version');
+        $direction = $this->option('down') ? 'down' : 'up';
+
+        $configuration = $this->getMigrationConfiguration();
+        $version = $configuration->getVersion($version);
+
+        $timeAllqueries = $this->option('query-time');
+
+        if ($path = $this->option('write-sql')) {
+            $path = is_bool($path) ? getcwd() : $path;
+            $version->writeSqlFile($path, $direction);
+        } else {
+            if ($this->input->isInteractive()) {
+                $execute = $this->confirm('WARNING! You are about to execute a database migration that could result in schema changes and data lost. Are you sure you wish to continue? (y/n)',
+                    false);
+            } else {
+                $execute = true;
+            }
+
+            if ($execute) {
+                $version->execute($direction, (boolean) $this->option('dry-run'));
+            } else {
+                $this->error('Migration cancelled!');
+            }
+        }
+    }
+
+    /**
+     * Get the console command arguments.
+     *
+     * @return array
+     */
+    protected function getArguments()
+    {
+        return [
+            ['version', InputArgument::REQUIRED, 'The version to execute.', null]
+        ];
+    }
+
+    /**
+     * Get the console command options.
+     *
+     * @return array
+     */
+    protected function getOptions()
+    {
+        $options = [
+            [
+                'write-sql',
+                null,
+                InputOption::VALUE_NONE,
+                'The path to output the migration SQL file instead of executing it.'
+            ],
+            ['dry-run', null, InputOption::VALUE_NONE, 'Execute the migration as a dry run.'],
+            ['up', null, InputOption::VALUE_NONE, 'Execute the migration up.'],
+            ['down', null, InputOption::VALUE_NONE, 'Execute the migration down.'],
+            ['query-time', null, InputOption::VALUE_NONE, 'Time all the queries individually.']
+        ];
+
+        return array_merge(parent::getOptions(), $options);
+    }
+
+}

--- a/src/Console/Migrations/GenerateCommand.php
+++ b/src/Console/Migrations/GenerateCommand.php
@@ -1,0 +1,123 @@
+<?php namespace Mitch\LaravelDoctrine\Console\Migrations;
+
+use Symfony\Component\Console\Input\InputOption;
+use Doctrine\DBAL\Migrations\Configuration\Configuration;
+
+class GenerateCommand extends AbstractCommand {
+
+    private static $_template =
+        '<?php
+
+namespace <namespace>;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version<version> extends AbstractMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+<up>
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+<down>
+    }
+}
+';
+
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $name = 'doctrine:migrations:generate';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Generate a blank migration class.';
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function fire()
+    {
+        $configuration = $this->getMigrationConfiguration();
+
+        $version = date('YmdHis');
+        $path = $this->generateMigration($configuration, $version);
+
+        $this->info(sprintf('Generated new migration class to "<info>%s</info>"', $path));
+    }
+
+    /**
+     * Get the console command options.
+     *
+     * @return array
+     */
+    protected function getOptions()
+    {
+        return [
+            [
+                'editor-cmd',
+                null,
+                InputOption::VALUE_OPTIONAL,
+                'Open file with this command upon creation.'
+            ]
+        ];
+    }
+
+    protected function generateMigration(Configuration $configuration, $version, $up = null, $down = null)
+    {
+        $placeHolders = array(
+            '<namespace>',
+            '<version>',
+            '<up>',
+            '<down>'
+        );
+
+        $replacements = array(
+            $configuration->getMigrationsNamespace(),
+            $version,
+            $up ? "        " . implode("\n        ", explode("\n", $up)) : null,
+            $down ? "        " . implode("\n        ", explode("\n", $down)) : null
+        );
+
+        $code = str_replace($placeHolders, $replacements, self::$_template);
+        $code = preg_replace('/^ +$/m', '', $code);
+        $dir = $configuration->getMigrationsDirectory();
+        $dir = $dir ? $dir : getcwd();
+        $dir = rtrim($dir, '/');
+        $path = $dir . '/Version' . $version . '.php';
+
+        if ( ! file_exists($dir)) {
+            throw new \InvalidArgumentException(sprintf('Migrations directory "%s" does not exist.', $dir));
+        }
+
+        file_put_contents($path, $code);
+
+        if ($editorCmd = $this->option('editor-cmd')) {
+            proc_open($editorCmd . ' ' . escapeshellarg($path), array(), $pipes);
+        }
+
+        return $path;
+    }
+
+}

--- a/src/Console/Migrations/LatestCommand.php
+++ b/src/Console/Migrations/LatestCommand.php
@@ -1,0 +1,30 @@
+<?php namespace Mitch\LaravelDoctrine\Console\Migrations;
+
+class LatestCommand extends AbstractCommand {
+
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $name = 'doctrine:migrations:latest';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Outputs the latest version number.';
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function fire()
+    {
+        $configuration = $this->getMigrationConfiguration();
+        $this->info($configuration->getLatestVersion());
+    }
+
+}

--- a/src/Console/Migrations/MigrateCommand.php
+++ b/src/Console/Migrations/MigrateCommand.php
@@ -1,0 +1,144 @@
+<?php namespace Mitch\LaravelDoctrine\Console\Migrations;
+
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Input\InputArgument;
+use Doctrine\DBAL\Migrations\Migration;
+
+class MigrateCommand extends AbstractCommand {
+
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $name = 'doctrine:migrations:migrate';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Execute a migration to a specified version or the latest available version.';
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function fire()
+    {
+        $configuration = $this->getMigrationConfiguration();
+        $migration = new Migration($configuration);
+
+        $this->outputHeader($configuration);
+        $noInteraction = !$this->input->isInteractive();
+
+        $timeAllqueries = $this->option('query-time');
+        $executedMigrations = $configuration->getMigratedVersions();
+        $availableMigrations = $configuration->getAvailableVersions();
+        $executedUnavailableMigrations = array_diff($executedMigrations, $availableMigrations);
+
+        $versionAlias = $this->argument('version');
+        $version = $configuration->resolveVersionAlias($versionAlias);
+        if ($version === null) {
+            switch ($versionAlias) {
+                case 'prev':
+                    $this->error('Already at first version.');
+                    break;
+                case 'next':
+                    $this->error('Already at latest version.');
+                    break;
+                default:
+                    $this->error('Unknown version: ' . $this->output->getFormatter()->escape($versionAlias) . '');
+            }
+
+            return 1;
+        }
+
+        if ($executedUnavailableMigrations) {
+            $this->error(sprintf('WARNING! You have %s previously executed migrations in the database that are not registered migrations.',
+                count($executedUnavailableMigrations)));
+
+            foreach ($executedUnavailableMigrations as $executedUnavailableMigration) {
+                $this->line('    <comment>>></comment> ' . $configuration->formatVersion($executedUnavailableMigration) . ' (<comment>' . $executedUnavailableMigration . '</comment>)');
+            }
+            if ( ! $noInteraction) {
+                $confirmation = $this->confirm('Are you sure you wish to continue? (y/n)', false);
+                if ( ! $confirmation) {
+                    $this->error('Migration cancelled!');
+
+                    return 1;
+                }
+            }
+        }
+
+        if ($path = $this->option('write-sql')) {
+            $path = is_bool($path) ? getcwd() : $path;
+            $migration->writeSqlFile($path, $version);
+        } else {
+            $dryRun = (boolean) $this->option('dry-run');
+            // warn the user if no dry run and interaction is on
+            if ( ! $dryRun && ! $noInteraction) {
+                $confirmation = $this->confirm('WARNING! You are about to execute a database migration that could result in schema changes and data lost. Are you sure you wish to continue? (y/n)', false);
+                if ( ! $confirmation) {
+                    $this->error('Migration cancelled!');
+
+                    return 1;
+                }
+            }
+            $sql = $migration->migrate($version, $dryRun, $timeAllqueries);
+            if ( ! $sql) {
+                $this->comment('No migrations to execute.');
+            }
+        }
+    }
+
+    /**
+     * Get the console command arguments.
+     *
+     * @return array
+     */
+    protected function getArguments()
+    {
+        return [
+            [
+                'version',
+                InputArgument::OPTIONAL,
+                'The version number (YYYYMMDDHHMMSS) or alias (first, prev, next, latest) to migrate to.',
+                'latest'
+            ],
+        ];
+    }
+
+    /**
+     * Get the console command options.
+     *
+     * @return array
+     */
+    protected function getOptions()
+    {
+        $options = [
+            [
+                'write-sql',
+                null,
+                InputOption::VALUE_NONE,
+                'The path to output the migration SQL file instead of executing it.'
+            ],
+            [
+                'dry-run',
+                null,
+                InputOption::VALUE_NONE,
+                'Execute the migration as a dry run.'
+            ],
+            [
+                'query-time',
+                null,
+                InputOption::VALUE_NONE,
+                'Time all the queries individually.'
+            ]
+        ];
+
+        return array_merge(parent::getOptions(), $options);
+    }
+
+}

--- a/src/Console/Migrations/StatusCommand.php
+++ b/src/Console/Migrations/StatusCommand.php
@@ -1,0 +1,123 @@
+<?php namespace Mitch\LaravelDoctrine\Console\Migrations;
+
+use Doctrine\DBAL\Migrations\Configuration\AbstractFileConfiguration;
+use Symfony\Component\Console\Input\InputOption;
+
+class StatusCommand extends AbstractCommand {
+
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $name = 'doctrine:migrations:status';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'View the status of a set of migrations.';
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function fire()
+    {
+        $configuration = $this->getMigrationConfiguration();
+
+        $formattedVersions = array();
+        foreach (array('prev', 'current', 'next', 'latest') as $alias) {
+            $version = $configuration->resolveVersionAlias($alias);
+            if ($version === null) {
+                if ($alias == 'next') {
+                    $formattedVersions[$alias] = 'Already at latest version';
+                } elseif ($alias == 'prev') {
+                    $formattedVersions[$alias] = 'Already at first version';
+                }
+            } elseif ($version === '0') {
+                $formattedVersions[$alias] = '<comment>0</comment>';
+            } else {
+                $formattedVersions[$alias] = $configuration->formatVersion($version) . ' (<comment>' . $version . '</comment>)';
+            }
+        }
+
+        $executedMigrations = $configuration->getMigratedVersions();
+        $availableMigrations = $configuration->getAvailableVersions();
+        $executedUnavailableMigrations = array_diff($executedMigrations, $availableMigrations);
+        $numExecutedUnavailableMigrations = count($executedUnavailableMigrations);
+        $newMigrations = count(array_diff($availableMigrations, $executedMigrations));
+
+        $this->line("\n <info>==</info> Configuration\n");
+
+        $info = array(
+            'Name'                            => $configuration->getName() ? $configuration->getName() : 'Doctrine Database Migrations',
+            'Database Driver'                 => $configuration->getConnection()->getDriver()->getName(),
+            'Database Name'                   => $configuration->getConnection()->getDatabase(),
+            'Configuration Source'            => $configuration instanceof AbstractFileConfiguration ? $configuration->getFile() : 'manually configured',
+            'Version Table Name'              => $configuration->getMigrationsTableName(),
+            'Migrations Namespace'            => $configuration->getMigrationsNamespace(),
+            'Migrations Directory'            => $configuration->getMigrationsDirectory(),
+            'Previous Version'                => $formattedVersions['prev'],
+            'Current Version'                 => $formattedVersions['current'],
+            'Next Version'                    => $formattedVersions['next'],
+            'Latest Version'                  => $formattedVersions['latest'],
+            'Executed Migrations'             => count($executedMigrations),
+            'Executed Unavailable Migrations' => $numExecutedUnavailableMigrations > 0 ? '<error>' . $numExecutedUnavailableMigrations . '</error>' : 0,
+            'Available Migrations'            => count($availableMigrations),
+            'New Migrations'                  => $newMigrations > 0 ? '<question>' . $newMigrations . '</question>' : 0
+        );
+        foreach ($info as $name => $value) {
+            $this->line('    <comment>>></comment> ' . $name . ': ' . str_repeat(' ',
+                    50 - strlen($name)) . $value);
+        }
+
+        if ($this->option('show-versions')) {
+            if ($migrations = $configuration->getMigrations()) {
+                $this->line("\n <info>==</info> Available Migration Versions\n");
+                $migratedVersions = $configuration->getMigratedVersions();
+                foreach ($migrations as $version) {
+                    $isMigrated = in_array($version->getVersion(), $migratedVersions);
+                    $status = $isMigrated ? '<info>migrated</info>' : '<error>not migrated</error>';
+                    $migrationName = $version->getMigration()->getDescription();
+                    if ($migrationName) {
+                        $migrationName = str_repeat(' ', 10) . $migrationName;
+                    }
+                    $this->line('    <comment>>></comment> ' . $configuration->formatVersion($version->getVersion()) .
+                        ' (<comment>' . $version->getVersion() . '</comment>)' .
+                        str_repeat(' ', 30 - strlen($name)) . $status . $migrationName);
+                }
+            }
+
+            if ($executedUnavailableMigrations) {
+                $this->line("\n <info>==</info> Previously Executed Unavailable Migration Versions\n");
+                foreach ($executedUnavailableMigrations as $executedUnavailableMigration) {
+                    $this->line('    <comment>>></comment> ' . $configuration->formatVersion($executedUnavailableMigration) .
+                        ' (<comment>' . $executedUnavailableMigration . '</comment>)');
+                }
+            }
+        }
+    }
+
+    /**
+     * Get the console command options.
+     *
+     * @return array
+     */
+    protected function getOptions()
+    {
+        $options = [
+            [
+                'show-versions',
+                null,
+                InputOption::VALUE_NONE,
+                'This will display a list of all available migrations and their status'
+            ]
+        ];
+
+        return array_merge(parent::getOptions(), $options);
+    }
+
+}

--- a/src/Console/Migrations/VersionCommand.php
+++ b/src/Console/Migrations/VersionCommand.php
@@ -1,0 +1,158 @@
+<?php namespace Mitch\LaravelDoctrine\Console\Migrations;
+
+use Doctrine\DBAL\Migrations\MigrationException;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Input\InputArgument;
+
+class VersionCommand extends AbstractCommand {
+
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $name = 'doctrine:migrations:version';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Manually add and delete migration versions from the version table.';
+
+    /**
+     * The Migrations Configuration instance
+     *
+     * @var \Doctrine\DBAL\Migrations\Configuration\Configuration
+     */
+    private $configuration;
+
+    /**
+     * Whether or not the versions have to be marked as migrated or not
+     *
+     * @var boolean
+     */
+    private $markMigrated;
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function fire()
+    {
+        $this->configuration = $this->getMigrationConfiguration();
+
+        if ( ! $this->option('add') && ! $this->option('delete')) {
+            throw new \InvalidArgumentException('You must specify whether you want to --add or --delete the specified version.');
+        }
+
+        $this->markMigrated = (boolean) $this->option('add');
+
+        if ($this->input->isInteractive()) {
+            $confirmation = $this->confirm('WARNING! You are about to add, delete or synchronize migration versions from the version table that could result in data lost. Are you sure you wish to continue? (y/n)',
+                false);
+            if ($confirmation) {
+                $this->markVersions();
+            } else {
+                $this->error('Migration cancelled!');
+            }
+        } else {
+            $this->markVersions();
+        }
+    }
+
+    /**
+     * Get the console command arguments.
+     *
+     * @return array
+     */
+    protected function getArguments()
+    {
+        return [
+            ['version', InputArgument::OPTIONAL, 'The version to add or delete.', null]
+        ];
+    }
+
+    /**
+     * Get the console command options.
+     *
+     * @return array
+     */
+    protected function getOptions()
+    {
+        $options = [
+            ['add', null, InputOption::VALUE_NONE, 'Add the specified version.'],
+            ['delete', null, InputOption::VALUE_NONE, 'Delete the specified version.'],
+            ['all', null, InputOption::VALUE_NONE, 'Apply to all the versions.'],
+            ['range-from', null, InputOption::VALUE_OPTIONAL, 'Apply from specified version.'],
+            ['range-to', null, InputOption::VALUE_OPTIONAL, 'Apply to specified version.']
+        ];
+
+        return array_merge(parent::getOptions(), $options);
+    }
+
+    private function markVersions()
+    {
+        $affectedVersion = $this->argument('version');
+
+        $allOption = $this->option('all');
+        $rangeFromOption = $this->option('range-from');
+        $rangeToOption = $this->option('range-to');
+
+        if ($allOption && ($rangeFromOption !== null || $rangeToOption !== null)) {
+            throw new \InvalidArgumentException('Options --all and --range-to/--range-from both used. You should use only one of them.');
+        } elseif ($rangeFromOption !== null ^ $rangeToOption !== null) {
+            throw new \InvalidArgumentException('Options --range-to and --range-from should be used together.');
+        }
+
+        if ($allOption === true) {
+            $availableVersions = $this->configuration->getAvailableVersions();
+            foreach ($availableVersions as $version) {
+                $this->mark($version, true);
+            }
+        } elseif ($rangeFromOption !== null && $rangeToOption !== null) {
+            $availableVersions = $this->configuration->getAvailableVersions();
+            foreach ($availableVersions as $version) {
+                if ($version >= $rangeFromOption && $version <= $rangeToOption) {
+                    $this->mark($version, true);
+                }
+            }
+        } else {
+            $this->mark($affectedVersion);
+        }
+    }
+
+    private function mark($version, $all = false)
+    {
+        if ( ! $this->configuration->hasVersion($version)) {
+            throw MigrationException::unknownMigrationVersion($version);
+        }
+
+        $version = $this->configuration->getVersion($version);
+        if ($this->markMigrated && $this->configuration->hasVersionMigrated($version)) {
+            $marked = true;
+            if ( ! $all) {
+                throw new \InvalidArgumentException(sprintf('The version "%s" already exists in the version table.',
+                    $version));
+            }
+        }
+
+        if ( ! $this->markMigrated && ! $this->configuration->hasVersionMigrated($version)) {
+            $marked = false;
+            if ( ! $all) {
+                throw new \InvalidArgumentException(sprintf('The version "%s" does not exists in the version table.',
+                    $version));
+            }
+        }
+
+        if ( ! isset($marked)) {
+            if ($this->markMigrated) {
+                $version->markMigrated();
+            } else {
+                $version->markNotMigrated();
+            }
+        }
+    }
+
+}

--- a/src/LaravelDoctrineServiceProvider.php
+++ b/src/LaravelDoctrineServiceProvider.php
@@ -65,6 +65,14 @@ class LaravelDoctrineServiceProvider extends ServiceProvider
             'Mitch\LaravelDoctrine\Console\CacheClearQueryCommand',
             'Mitch\LaravelDoctrine\Console\CacheClearQueryRegionCommand',
             'Mitch\LaravelDoctrine\Console\CacheClearResultCommand'
+            'Mitch\LaravelDoctrine\Console\ConvertMapping',
+            'Mitch\LaravelDoctrine\Console\Migrations\GenerateCommand',
+            'Mitch\LaravelDoctrine\Console\Migrations\DiffCommand',
+            'Mitch\LaravelDoctrine\Console\Migrations\MigrateCommand',
+            'Mitch\LaravelDoctrine\Console\Migrations\ExecuteCommand',
+            'Mitch\LaravelDoctrine\Console\Migrations\LatestCommand',
+            'Mitch\LaravelDoctrine\Console\Migrations\StatusCommand',
+            'Mitch\LaravelDoctrine\Console\Migrations\VersionCommand',
         ]);
     }
 

--- a/src/LaravelDoctrineServiceProvider.php
+++ b/src/LaravelDoctrineServiceProvider.php
@@ -64,7 +64,7 @@ class LaravelDoctrineServiceProvider extends ServiceProvider
             'Mitch\LaravelDoctrine\Console\CacheClearEntityRegionCommand',
             'Mitch\LaravelDoctrine\Console\CacheClearQueryCommand',
             'Mitch\LaravelDoctrine\Console\CacheClearQueryRegionCommand',
-            'Mitch\LaravelDoctrine\Console\CacheClearResultCommand'
+            'Mitch\LaravelDoctrine\Console\CacheClearResultCommand',
             'Mitch\LaravelDoctrine\Console\ConvertMapping',
             'Mitch\LaravelDoctrine\Console\Migrations\GenerateCommand',
             'Mitch\LaravelDoctrine\Console\Migrations\DiffCommand',


### PR DESCRIPTION
This adds support for all migration console commands as well as the convert mapping console command.

Here is a list of all commands added:
- `doctrine:migrations:migrate`
- `doctrine:migrations:diff`
- `doctrine:migrations:execute`
- `doctrine:migrations:generate`
- `doctrine:migrations:latest`
- `doctrine:migrations:status`
- `doctrine:migrations:version`
- `doctrine:mapping:convert`
