### PR TITLE
Fix migrations

### DIFF
--- a/src/Console/Helper/CommandHelper.php
+++ b/src/Console/Helper/CommandHelper.php
@@ -4,30 +4,55 @@ use Mitch\LaravelDoctrine\IlluminateRegistry;
 use Doctrine\DBAL\Tools\Console\Helper\ConnectionHelper;
 use Doctrine\ORM\Tools\Console\Helper\EntityManagerHelper;
 use Doctrine\DBAL\Migrations\Tools\Console\Command\AbstractCommand;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Application;
+use Doctrine\DBAL\Migrations\Configuration\Configuration;
 
 class CommandHelper 
 {
-    public function setApplicationHelpers(Application $application, InputInterface $input)
+    public static function setApplicationHelper(Application $application, InputInterface $input)
     {
         $laravel = $application->getLaravel();
         $registry = $laravel[IlluminateRegistry::class];
-        $entityManager = $registry->getManager($input->getOption('em'));
-        
-        $helperSet = $application->getHelperSet();
-        $helperSet->set(new ConnectionHelper($entityManager->getConnection()), 'db');
-        $helperSet->set(new EntityManagerHelper($entityManager), 'em');
+        $managerNames = $registry->getManagerNames();
+
+        if (empty($managerNames)) {
+            self::setApplicationConnection($application, $input->getOption('db'));
+        } else {
+            self::setApplicationEntityManager($application, $input->getOption('em'));
+        }
     }
 
-    public function setMigrationConfiguration(Application $application, AbstractCommand $command)
+    public static function setApplicationConnection(Application $application, $connName)
     {
         $laravel = $application->getLaravel();
-        $config = $laravel['config']('doctrine.migrations');
+        $connection = $laravel[IlluminateRegistry::class]->getConnection($connName);
+
+        $helperSet = $application->getHelperSet();
+        $helperSet->set(new ConnectionHelper($connection), 'db');
+    }
+
+    public static function setApplicationEntityManager(Application $application, $emName)
+    {
+        $laravel = $application->getLaravel();
+        $em = $laravel[IlluminateRegistry::class]->getManager($emName);
+         
+        $helperSet = $application->getHelperSet();
+        $helperSet->set(new EntityManagerHelper($em), 'em');
+        $helperSet->set(new ConnectionHelper($em->getConnection()), 'db');
+    }
+
+    public static function setMigrationConfiguration(Application $application, AbstractCommand $command)
+    {
+        $laravel = $application->getLaravel();
+        $config = $laravel['config']->get('doctrine.migrations');
         $directory = array_get($config, 'directory');
         if ( ! is_dir($directory)) {
             mkdir($directory, 0777, true);
         }
 
-        $configuration = new Configuration($this->getHelper('connection')->getConnection());
+        $configuration = new Configuration($application->getHelperSet()->get('connection')->getConnection());
         $configuration->setMigrationsDirectory(array_get($config, 'directory'));
         $configuration->setMigrationsNamespace(array_get($config, 'namespace'));
         $configuration->setMigrationsTableName(array_get($config, 'table', 'doctrine_migration_versions'));

--- a/src/Console/Helper/CommandHelper.php
+++ b/src/Console/Helper/CommandHelper.php
@@ -1,0 +1,38 @@
+<?php  namespace Mitch\LaravelDoctrine\Console\Helper;
+
+use Mitch\LaravelDoctrine\IlluminateRegistry;
+use Doctrine\DBAL\Tools\Console\Helper\ConnectionHelper;
+use Doctrine\ORM\Tools\Console\Helper\EntityManagerHelper;
+use Doctrine\DBAL\Migrations\Tools\Console\Command\AbstractCommand;
+
+class CommandHelper 
+{
+    public function setApplicationHelpers(Application $application, InputInterface $input)
+    {
+        $laravel = $application->getLaravel();
+        $registry = $laravel[IlluminateRegistry::class];
+        $entityManager = $registry->getManager($input->getOption('em'));
+        
+        $helperSet = $application->getHelperSet();
+        $helperSet->set(new ConnectionHelper($entityManager->getConnection()), 'db');
+        $helperSet->set(new EntityManagerHelper($entityManager), 'em');
+    }
+
+    public function setMigrationConfiguration(Application $application, AbstractCommand $command)
+    {
+        $laravel = $application->getLaravel();
+        $config = $laravel['config']('doctrine.migrations');
+        $directory = array_get($config, 'directory');
+        if ( ! is_dir($directory)) {
+            mkdir($directory, 0777, true);
+        }
+
+        $configuration = new Configuration($this->getHelper('connection')->getConnection());
+        $configuration->setMigrationsDirectory(array_get($config, 'directory'));
+        $configuration->setMigrationsNamespace(array_get($config, 'namespace'));
+        $configuration->setMigrationsTableName(array_get($config, 'table', 'doctrine_migration_versions'));
+        $configuration->registerMigrationsFromDirectory(array_get($config, 'directory'));
+
+        $command->setMigrationConfiguration($configuration);
+    }
+}


### PR DESCRIPTION
The `doctrine:migrations:migrate` command is currently broken with the latest version of the doctrine/migrations package (see [this screengrab](https://cloud.githubusercontent.com/assets/52687/8664202/5d903df2-2a17-11e5-8f10-c4ff7ee09627.png))

I've re-written the MigrateCommand to extend the MigrateCommand that Doctrine. The CommandHelper class has been added to assist in configuring the application helpers that the Doctrine MigrateCommand is expecting, in order to access the Connection and Entity Manager.

As a side-benefit, this should now also support multiple entity managers / database connections, with the --em and --db flags, though I haven't tested it.

Most of this code is based on the DoctrineMigrations Symfony bundle: https://github.com/doctrine/DoctrineMigrationsBundle/blob/master/Command/MigrationsMigrateDoctrineCommand.php
