### PR TITLE
Fixing isDeleted method to handle null values

### DIFF
--- a/src/Traits/SoftDeletes.php
+++ b/src/Traits/SoftDeletes.php
@@ -20,6 +20,6 @@ trait SoftDeletes {
     }
 
     public function isDeleted() {
-        return new DateTime > $this->deletedAt;
+        return ($this->deletedAt) ? new DateTime > $this->deletedAt : false;
     }
 }


### PR DESCRIPTION
Noticed the isDelete() function didn't work when the value in the database was null (which it is as default).

This ensures the correct result is given.
